### PR TITLE
eth/protocols/eth: use rlp.RawList to express Sidecars

### DIFF
--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -796,6 +796,7 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 	var txLists [][]*types.Transaction
 	var uncleLists [][]*types.Header
 	var withdrawalLists [][]*types.Withdrawal
+	var sidecarLists []types.BlobSidecars
 
 	validate := func(index int, header *types.Header) error {
 		if hashes.TransactionRoots[index] != header.TxHash {
@@ -838,12 +839,19 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		} else {
 			withdrawalLists = append(withdrawalLists, nil)
 		}
-
-		// do some sanity check for sidecar
-		for _, sidecar := range bodies[index].Sidecars {
-			if err := sidecar.SanityCheck(header.Number, header.Hash()); err != nil {
-				return err
+		if bodies[index].Sidecars != nil {
+			sidecars, err := bodies[index].Sidecars.Items()
+			if err != nil {
+				return fmt.Errorf("%w: bad withdrawals: %v", errInvalidBody, err)
 			}
+			for _, sidecar := range sidecars {
+				if err := sidecar.SanityCheck(header.Number, header.Hash()); err != nil {
+					return err
+				}
+			}
+			sidecarLists = append(sidecarLists, sidecars)
+		} else {
+			sidecarLists = append(sidecarLists, nil)
 		}
 		return nil
 	}
@@ -852,7 +860,7 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		result.Transactions = txLists[index]
 		result.Uncles = uncleLists[index]
 		result.Withdrawals = withdrawalLists[index]
-		result.Sidecars = bodies[index].Sidecars
+		result.Sidecars = sidecarLists[index]
 		result.SetBodyDone()
 	}
 	nresults := len(hashes.TransactionRoots)

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -842,7 +842,7 @@ func (q *queue) DeliverBodies(id string, hashes eth.BlockBodyHashes, bodies []et
 		if bodies[index].Sidecars != nil {
 			sidecars, err := bodies[index].Sidecars.Items()
 			if err != nil {
-				return fmt.Errorf("%w: bad withdrawals: %v", errInvalidBody, err)
+				return fmt.Errorf("%w: bad sidecars: %v", errInvalidBody, err)
 			}
 			for _, sidecar := range sidecars {
 				if err := sidecar.SanityCheck(header.Number, header.Hash()); err != nil {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -614,7 +614,15 @@ func (f *BlockFetcher) loop() {
 								f.dropPeer(peer)
 								return
 							}
-							sidecars[i] = body.Sidecars
+							if body.Sidecars != nil {
+								if sidecars[i], err = body.Sidecars.Items(); err != nil {
+									log.Debug("Failed to decode block body sidecars", "peer", peer, "err", err)
+									f.dropPeer(peer)
+									return
+								}
+							} else {
+								sidecars[i] = nil
+							}
 						}
 						f.FilterBodies(peer, txs, uncles, sidecars, time.Now())
 

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -298,8 +298,8 @@ type BlockBodiesResponse []BlockBody
 type BlockBody struct {
 	Transactions rlp.RawList[*types.Transaction]
 	Uncles       rlp.RawList[*types.Header]
-	Withdrawals  *rlp.RawList[*types.Withdrawal] `rlp:"optional"`
-	Sidecars     types.BlobSidecars              `rlp:"optional"`
+	Withdrawals  *rlp.RawList[*types.Withdrawal]  `rlp:"optional"`
+	Sidecars     *rlp.RawList[*types.BlobSidecar] `rlp:"optional"`
 }
 
 // GetReceiptsRequest represents a block receipts query.


### PR DESCRIPTION
### Description

eth/protocols/eth: use rlp.RawList to express Sidecars

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
